### PR TITLE
Initialization fix + testing for consistency

### DIFF
--- a/Exec/DevTests/ABL_perturbation_inflow/compressible_source_inputs
+++ b/Exec/DevTests/ABL_perturbation_inflow/compressible_source_inputs
@@ -2,7 +2,6 @@
 stop_time = 180.0
 #max_step = 5
 
-erf.no_substepping = 1
 amrex.fpe_trap_invalid = 1
 fabarray.mfiter_tile_size = 1024 1024 1024
 
@@ -34,15 +33,14 @@ xlo.theta   = 300.0
 xlo.dirichlet_file = "input_ReTau395Ana_inflow.txt"
 
 # TIME STEP CONTROL
-#erf_.cfl = 0.8
-erf.fixed_dt = 0.0001
+erf.fixed_dt = 0.0002
 erf.fixed_mri_dt_ratio = 4
 erf.dynamicViscosity = 0.001
 
 # DIAGNOSTICS & VERBOSITY
 erf.sum_interval   = 100     # timesteps between computing mass
 erf.pert_interval  = 100     # timesteps between perturbation output message XXX
-erf.v              = 1       # verbosity in ERF.cpp XXX
+erf.v              = 0       # verbosity in ERF.cpp XXX
 amr.v              = 0       # verbosity in Amr.cpp
 
 # REFINEMENT / REGRIDDING
@@ -51,7 +49,6 @@ amr.max_level       = 0      # maximum level number allowed
 # PLOTFILES
 erf.plot_file_1     = plt    # prefix of plotfile name
 erf.plot_per_1      = 0.1
-#erf.plot_int_1      = 5
 erf.plot_vars_1     = density rhoadv_0 x_velocity y_velocity z_velocity pressure temp theta
 
 # CHECKPOINT FILES
@@ -74,9 +71,9 @@ erf.perturbation_layers = 3
 erf.perturbation_offset = 3
 
 erf.perturbation_box_dims = 8 8 4
+#erf.perturbation_nondimensional = 0.042 # Ri
 erf.perturbation_nondimensional = 0.1 # Ri
 erf.perturbation_T_infinity = 300.0
-#erf.perturbation_T_intensity = 0.1
 
 # Initial condition for the entire field
 #erf.init_type = "uniform"

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -441,6 +441,7 @@ private:
 
     // Initialize the Turbulent perturbation
     void turbPert_update (const int lev, const amrex::Real dt);
+    void turbPert_amplitude (const int lev);
 
     // Initialize the integrator object
     void initialize_integrator (int lev, amrex::MultiFab& cons_mf, amrex::MultiFab& vel_mf);

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1255,6 +1255,7 @@ ERF::init_only (int lev, Real time)
         solverChoice.pert_type == PerturbationType::perturbDirect) {
         if (lev == 0) {
             turbPert_update(lev, 0.);
+            turbPert_amplitude(lev);
         }
     }
 }

--- a/Source/Initialization/ERF_init_TurbPert.cpp
+++ b/Source/Initialization/ERF_init_TurbPert.cpp
@@ -37,3 +37,30 @@ ERF::turbPert_update (const int lev, const Real local_dt)
 
     Print() << "Successfully initialized turbulent perturbation update time and amplitude with type: "<< turbPert.pt_type <<"\n";
 }
+
+// Calculate the perturbation region amplitude.
+// This function heavily emmulates the ERF::init_custom ()
+void
+ERF::turbPert_amplitude (int lev)
+{
+    // Accessing data
+    auto& lev_new = vars_new[lev];
+
+    // Creating local data
+    int ncons = lev_new[Vars::cons].nComp();
+    MultiFab cons_data(lev_new[Vars::cons], make_alias, 0, ncons);
+
+    // Defining BoxArray type
+    auto m_ixtype = cons_data.boxArray().ixType();
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(lev_new[Vars::cons], TileNoZ()); mfi.isValid(); ++mfi) {
+        const Box &bx  = mfi.validbox();
+        const auto &cons_pert_arr = cons_data.array(mfi); // Address of perturbation array
+        const amrex::Array4<const amrex::Real> &pert_cell = turbPert.pb_cell.array(mfi); // per-cell perturbation stored in structure
+
+        turbPert.apply_tpi(lev, bx, RhoTheta_comp, m_ixtype, cons_pert_arr, pert_cell);
+    } // mfi
+}


### PR DESCRIPTION
Seeing the `rhoTheta` source perturbation initialize with some sounding waves. It quickly clears within the first second of the simulation, now waiting for the downstream to become perturbed.